### PR TITLE
Update TcpClient.cs

### DIFF
--- a/FreestylerRemote/TcpClient.cs
+++ b/FreestylerRemote/TcpClient.cs
@@ -13,17 +13,16 @@ namespace FreestylerRemote
 {
     internal class TCPClient
     {
-        private string _ipAddress = "127.0.0.1";
-        private int _port = 3332;
+        private const string FreestylerIp = "127.0.0.1";
+        private const int FreestylerPort = 3332;
+        private readonly IPEndPoint _serverEndPoint = new IPEndPoint(IPAddress.Parse(FreestylerIp), FreestylerPort); 
         private TcpClient _client;
-        private IPEndPoint _serverEndPoint;
         private NetworkStream _clientStream;
         private StreamWriter _writer;
 
         public TCPClient()
         {
             _client = new TcpClient();
-            _serverEndPoint = new IPEndPoint(IPAddress.Parse(_ipAddress), _port);
         }
 
         ~TCPClient()
@@ -55,10 +54,10 @@ namespace FreestylerRemote
             const int release = 0;
 
             //F,S,O,D,Blackout,Spare,Click,Spare,Spare
-            byte[] buffer = new byte[9] { 70, 83, 79, 68, cmd1, cmd2, click, 0, 0 };
+            byte[] buffer = { 70, 83, 79, 68, cmd1, cmd2, click, 0, 0 };
             
             //F,S,O,D,Blackout,Spare,Release,Spare,Spare
-            byte[] buffer2 = new byte[9] { 70, 83, 79, 68, cmd1, cmd2, release, 0, 0 };
+            byte[] buffer2 = { 70, 83, 79, 68, cmd1, cmd2, release, 0, 0 };
 
             _clientStream.Write(buffer, 0, buffer.Length);
             _clientStream.Flush();
@@ -69,8 +68,6 @@ namespace FreestylerRemote
 
         internal void Send(string code, string arg, string opt="")
         {
-            const string click = "255";
-            const string release = "0";
 
             //F,S,O,C,Code ("xxx"),TCP/IP Arg (Click/Release or Fader Value), Optional ("zzz")
             string buffer = "FSOC" + code + arg; // + opt;
@@ -98,6 +95,7 @@ namespace FreestylerRemote
                 _client.Close();
                 _client = null;
             }
+
         }
     }
 }


### PR DESCRIPTION
Updated TCPClient.cs

- changed _ipAddress & _port vars to constants
- added readonly modifier to _serverEndPoint and initialized at point of declaration
- updated Send(byte cmd1, byte cmd2) method to remove redundant array creation
- updated Send(string code, string arg, string opt="") method to remove unused constants